### PR TITLE
Fix go mod tidy by removing envtest printer

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -43,10 +42,7 @@ var testEnv *envtest.Environment
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
-
-	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
-		[]Reporter{printer.NewlineReporter{}})
+	RunSpecs(t, "Controller Suite")
 }
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
## Summary
- remove dependency on `sigs.k8s.io/controller-runtime/pkg/envtest/printer`
- update tests to use `RunSpecs` instead of custom reporter

## Testing
- `go mod tidy`


------
https://chatgpt.com/codex/tasks/task_e_683f4def07fc832099bdc0b8ad196e19