### PR TITLE
Fix tests build issue

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,6 +30,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	configv1alpha1 "github.com/snapp-incubator/node-config-operator/api/v1alpha1"
 	"github.com/snapp-incubator/node-config-operator/controllers"
@@ -66,9 +68,13 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
-		MetricsBindAddress:     metricsAddr,
-		Port:                   9443,
+		Scheme: scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: metricsAddr,
+		},
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Port: 9443,
+		}),
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "97a91c42.snappcloud.io",


### PR DESCRIPTION
## Summary
- update controller manager options for controller-runtime v0.16

## Testing
- `go test ./...` *(fails: timeout waiting for process kube-apiserver to start successfully)*

------
https://chatgpt.com/codex/tasks/task_e_683f571eeaac8320b6775c8cf7e5024d