### PR TITLE
Fix make manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,9 @@ REG = registry.okd4.teh-1.snappcloud.io
 # Image URL to use all building/pushing image targets
 IMG ?= ${REG}/public-reg/node-config-operator:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= crd:trivialVersions=true,preserveUnknownFields=false
+# controller-gen v0.18 removed the trivialVersions and preserveUnknownFields
+# options. Use the plain 'crd' generator with default settings.
+CRD_OPTIONS ?= crd
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/config/crd/bases/config.snappcloud.io_nodeconfigs.yaml
+++ b/config/crd/bases/config.snappcloud.io_nodeconfigs.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: nodeconfigs.config.snappcloud.io
 spec:
   group: config.snappcloud.io
@@ -22,14 +20,19 @@ spec:
         description: NodeConfig is the Schema for the nodeconfigs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -55,21 +58,24 @@ spec:
                     type: object
                   taints:
                     items:
-                      description: The node this Taint is attached to has the "effect"
-                        on any pod that does not tolerate the Taint.
+                      description: |-
+                        The node this Taint is attached to has the "effect" on
+                        any pod that does not tolerate the Taint.
                       properties:
                         effect:
-                          description: Required. The effect of the taint on pods that
-                            do not tolerate the taint. Valid effects are NoSchedule,
-                            PreferNoSchedule and NoExecute.
+                          description: |-
+                            Required. The effect of the taint on pods
+                            that do not tolerate the taint.
+                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
                         key:
                           description: Required. The taint key to be applied to a
                             node.
                           type: string
                         timeAdded:
-                          description: TimeAdded represents the time at which the
-                            taint was added. It is only written for NoExecute taints.
+                          description: |-
+                            TimeAdded represents the time at which the taint was added.
+                            It is only written for NoExecute taints.
                           format: date-time
                           type: string
                         value:
@@ -91,9 +97,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,37 +1,9 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
 rules:
-- apiGroups:
-  - config.snappcloud.io
-  resources:
-  - nodeconfigs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - config.snappcloud.io
-  resources:
-  - nodeconfigs/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - config.snappcloud.io
-  resources:
-  - nodeconfigs/status
-  verbs:
-  - get
-  - patch
-  - update
 - apiGroups:
   - ""
   resources:
@@ -54,6 +26,32 @@ rules:
   - ""
   resources:
   - nodes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - config.snappcloud.io
+  resources:
+  - nodeconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - config.snappcloud.io
+  resources:
+  - nodeconfigs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - config.snappcloud.io
+  resources:
+  - nodeconfigs/status
   verbs:
   - get
   - patch

--- a/go.sum
+++ b/go.sum
@@ -1289,6 +1289,7 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
 golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/exp v0.0.0-20220827204233-334a2380cb91 h1:tnebWN09GYg9OLPss1KXj8txwZc6X6uMr6VFdcGNbHw=
 golang.org/x/exp v0.0.0-20220827204233-334a2380cb91/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=


### PR DESCRIPTION
## Summary
- fix CRD generation flags for controller-gen v0.18
- update generated CRDs and RBAC
- add missing dependency entry

## Testing
- `make manifests`
- `make test` *(fails: TestAPIs)*

------
https://chatgpt.com/codex/tasks/task_e_683f5c6d98c88320873f7e4a049c5c22